### PR TITLE
Fix Docker volume leak in bulk test cleanup

### DIFF
--- a/cleanup-containers.sh
+++ b/cleanup-containers.sh
@@ -31,4 +31,15 @@ else
     echo "ℹ️  PostgreSQL indexed container not found"
 fi
 
-echo "🎉 Database container cleanup complete!"
+# Clean up any orphaned volumes from database containers
+echo "🧹 Cleaning up orphaned Docker volumes..."
+ORPHANED_VOLUMES=$(docker volume ls -q --filter dangling=true)
+if [ ! -z "$ORPHANED_VOLUMES" ]; then
+    echo "Removing $(echo "$ORPHANED_VOLUMES" | wc -l) orphaned volume(s)..."
+    echo "$ORPHANED_VOLUMES" | xargs docker volume rm
+    echo "✅ Orphaned volumes cleaned up"
+else
+    echo "ℹ️  No orphaned volumes to clean"
+fi
+
+echo "🎉 Database container and volume cleanup complete!"


### PR DESCRIPTION
- Add orphaned volume cleanup to cleanup-containers.sh
- Prevents Docker storage exhaustion during bulk test runs
- Each test cycle now properly cleans up its database volumes
- Fixes "no space left on device" errors during repeated testing

Before: kill-dbs only removed containers, leaving volumes behind
After: kill-dbs removes both containers and orphaned volumes

🤖 Generated with [Claude Code](https://claude.ai/code)